### PR TITLE
Bump build for libprotobuf & dependency tweaks.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ checksum }}
 
 build:
-  number: 3
+  number: 4
   skip: true  # [(win and vc<14) or win32]
   run_exports:
     - {{ pin_subpackage("arrow-cpp", max_pin="x.x.x") }}
@@ -40,8 +40,11 @@ requirements:
     - utf8proc
     - numpy-devel >=1.14
     - libboost
-    - thrift-cpp >=0.13
+    # hard pinning for one build..
+    # - thrift-cpp >=0.13
+    - thrift-cpp 0.13
   host:
+    - abseil-cpp    # [not win]
     - aws-sdk-cpp
     - boost-cpp
     - brotli
@@ -59,7 +62,9 @@ requirements:
     - rapidjson
     - re2
     - snappy
-    - thrift-cpp >=0.13
+    # hard pinning for one build..
+    # - thrift-cpp >=0.13
+    - thrift-cpp 0.13
     - uriparser
     - zlib
     - zstd


### PR DESCRIPTION
OmniSciDB needs `thrift-cpp 0.13` pinned. This will become the master branch for that until the recipe can be updated to accommodate two variants, latest `thrift-cpp` & `thrift-cpp 0.13`.