### PR TITLE
Rebuild arrow-cpp 4.0.1 against protobuf 3.14

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,2 @@
+libprotobuf:  # [linux64]
+- 3.14        # [linux64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,11 +8,11 @@ package:
 
 source:
   fn: {{ filename }}
-  url: https://dist.apache.org/repos/dist/release/arrow/arrow-{{ version }}/{{ filename }}
+  url: https://archive.apache.org/dist/arrow/arrow-{{ version }}/{{ filename }}
   sha256: {{ checksum }}
 
 build:
-  number: 3
+  number: 4
   skip: true  # [(win and vc<14) or win32]
   run_exports:
     - {{ pin_subpackage("arrow-cpp", max_pin="x.x.x") }}
@@ -35,7 +35,8 @@ requirements:
     - libprotobuf
     - gnuconfig   # [osx and arm64]
     - grpc-cpp
-    - cmake
+    # See https://github.com/aws/aws-sdk-cpp/issues/1820
+    - cmake  <3.22
     - autoconf  # [unix]
     - ninja
     - make      # [unix]


### PR DESCRIPTION
Rebuild arrow against protobuf 3.14 on linux-64, so that it can be installed together with tensorflow 2.5.
