### PR TITLE
Make Python an explicit runtime dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -87,7 +87,7 @@ requirements:
     # It's not clear to me, why conda-build detects them, but doesn't create
     # an automatic dependency.
     - zlib  # [win]
-    - python  # [win]
+    - python
 
 test:
   requires:


### PR DESCRIPTION
This is a follow up to: https://github.com/AnacondaRecipes/arrow-cpp-feedstock/pull/17.