### PR TITLE
arrow-cpp 8.0.0 rebuild

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -86,7 +86,7 @@ requirements:
     - utf8proc
     # It's not clear to me, why conda-build detects them, but doesn't create
     # an automatic dependency.
-    - zlib  # [win]
+    - zlib
     - python
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - "0005-tracing-internal-include.patch"  # [win]
 
 build:
-  number: 0
+  number: 1
   # s390x is missing gflags, glog, utf8proc, thrift-cpp
   skip: true  # [win32 or s390x]
   run_exports:


### PR DESCRIPTION
## Changes 
- Rebuild to use shared version of `zlib`

## Notes

The recent rebuild of `orc 1.7.4` removed the statically-linked `zlib`, which caused `pyarrow 8` to stop functioning due to `libarrow`'s reliance on the `zlib` previously contained in `orc`. This rebuild of `arrow-cpp` uses the shared version of `zlib` since it is no longer present in `orc`, which in turn resolves the issue for `pyarrow 8`.