### PR TITLE
arrow-cpp 10.0.1 b1 - Rebuild against openssl 3.0.x

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,7 +67,7 @@ requirements:
     - utf8proc 2.6.1
     - zlib {{ zlib }}
     - zstd {{ zstd }}
-    - xsimd 10.0.0
+    - xsimd 11.0.0
   run:
     # gflags does have a run_exports, but for some reason conda-build doesn't
     # pick it up.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,7 +67,7 @@ requirements:
     - utf8proc 2.6.1
     - zlib {{ zlib }}
     - zstd {{ zstd }}
-    - xsimd 11.0.0
+    - xsimd 10.0.0
   run:
     # gflags does have a run_exports, but for some reason conda-build doesn't
     # pick it up.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,7 +63,7 @@ requirements:
     - re2 2022.04.01
     - snappy 1.1.9
     - thrift-cpp 0.15.0
-    - uriparser 0.9.3
+    - uriparser 0.9.7
     - utf8proc 2.6.1
     - zlib {{ zlib }}
     - zstd {{ zstd }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,8 @@ requirements:
     # To have the thrift compiler as a build tool.
     - thrift-cpp
   host:
+    # abseil-cpp 20230802.0 causing the UnsatisfibleDependency error so for this rebuild to work, 
+    # we need to pin it to the version 20211102.0 like it was done for arrow-cpp 11.0.0.
     - abseil-cpp 20211102.0  # [not osx]
     - aws-sdk-cpp 1.8.185
     - boost-cpp 1.82

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ requirements:
     # To have the thrift compiler as a build tool.
     - thrift-cpp
   host:
-    - abseil-cpp 20230802.0  # [not osx]
+    - abseil-cpp 20211102.0  # [not osx]
     - aws-sdk-cpp 1.8.185
     - boost-cpp 1.82
     - brotli 1.0.9
@@ -63,7 +63,7 @@ requirements:
     - re2 2022.04.01
     - snappy 1.1.9
     - thrift-cpp 0.15.0
-    - uriparser 0.9.7
+    - uriparser 0.9.3
     - utf8proc 2.6.1
     - zlib {{ zlib }}
     - zstd {{ zstd }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -130,7 +130,7 @@ about:
   license: Apache-2.0
   license_file: LICENSE.txt
   license_family: Apache
-  summary: 'C++ libraries for Apache Arrow'
+  summary: C++ libraries for Apache Arrow
   description: |
     Apache Arrow defines a language-independent columnar memory format
     for flat and hierarchical data, organized for efficient analytic operations


### PR DESCRIPTION
Actions:
1. Bump the build number to `1`
2. Update host pinnings

Notes:
- To fix the issue with openssl 1.1.1w in the test environment for snowflake-ml-python 1.0.8:
The real chain is:
`openssl 1.1.1w-h2f4d8fa_0 -> grpc-cpp	1.46.1 -> arrow-cpp 10.0.1-> snowflake-connector-python 3.1.0 -> snowflake-ml-python 1.0.8`
The root cause is the pinning 10.0.1 for arrow-cpp and pyarrow inside the recipe of snowflake-connector-python 3.1.0/3.2.0 https://github.com/AnacondaRecipes/snowflake-connector-python-feedstock/pull/13/files#diff-f3725a55bf339595bf865fec73bda8ac99f283b0810c205442021f29c06eea9aR47-R48

- The current build number on defaults is `0`:
```
arrow-cpp                     10.0.1 py310h1fc3239_0  pkgs/main
arrow-cpp                     10.0.1 py311h5aa4e29_0  pkgs/main
arrow-cpp                     10.0.1  py38h0fd5f32_0  pkgs/main
arrow-cpp                     10.0.1  py39h0fd5f32_0  pkgs/main
```