### PR TITLE
build against openssl 1.x, introduce new version

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,7 @@
+upload_without_merge: true
 upload_channels:
-  - sfe1ed40
+#  - sfe1ed40
+  - marekw
+
+channels:
+  - marekw

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,2 @@
-upload_without_merge: true
 upload_channels:
-#  - sfe1ed40
-  - marekw
-
-channels:
-  - marekw
+  - sfe1ed40

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -48,8 +48,6 @@ cmake -G "Ninja" ^
       -DCMAKE_PREFIX_PATH=%PREFIX% ^
       -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
       -DCMAKE_INSTALL_LIBDIR="%LIBRARY_PREFIX%" ^
-      -DPYTHON_EXECUTABLE="%PYTHON%" ^
-      -DPython3_EXECUTABLE="%PYTHON%" ^
       ..
 
 cmake --build . --target install --config Release

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,6 +1,7 @@
 #openssl 1.1.x required by customer
 openssl:
-  - 1.1
+  - 1.1.1
+  - 3.0
 
 MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
   - "10.13"                # [osx and x86_64]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,7 +1,10 @@
 #openssl 1.1.x required by customer
-openssl:
-  - 1.1.1
-  - 3.0
+#openssl:
+#  - 1.1.1
+#  - 3.0
+openssl_variant:
+  - current
+  - legacy
 
 MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
   - "10.13"                # [osx and x86_64]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,5 @@
 #openssl 1.1.x required by customer
+#following does not work, see https://github.com/conda/conda-build/issues/5038
 #openssl:
 #  - 1.1.1
 #  - 3.0

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,4 @@
+#openssl 1.1.x required by customer
 openssl:
   - 1.1
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,6 @@
+openssl:
+  - 1.1
+
 MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
   - "10.13"                # [osx and x86_64]
 MACOSX_SDK_VERSION:        # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,6 +57,7 @@ requirements:
     - glog 0.5.0
     - grpc-cpp 1.48.2
     - lz4-c 1.9.4
+#following does not work, see https://github.com/conda/conda-build/issues/5038
 #    - openssl {{ openssl }}
     - openssl 1.1.1 # [openssl_variant == "current"]
     - openssl 3.0 # [openssl_variant == "legacy"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,23 +6,16 @@
 {% set filename = "apache-arrow-" + version + ".tar.gz" %}
 {% set sha256 = "c814e0670112a22c1a6ec03ab420a52ae236a9a42e9e438c3cbd37f37e658fb3" %}
 
-
-# IMPORTANT NOTICE!!!
-# This package relies on openssl 1.x so its dependency tree is the next:
-# snowpark_python 1.7.0+openssl1 (submodule and folder are snowpark-python-1.7.0-feedstock; the branch is main-1.8.0)
-#  └─ snowflake_connector 3.2.0+openssl1 (submodule and folder are snowflake-connector-python-3.2.0-feedstock; the branch is master-3.2.0)
-# ===>     └─ arrow_cpp 10.0.1+openssl1 (submodule and folder are arrow-cpp-10.0.1-openssl1-feedstock; the branch is arrow-cpp-10.0.1)
-#          └─ openssl 1.x
 package:
   name: arrow-cpp
-  version: {{ version }}+openssl1
+  version: {{ version }}
 
 source:
   url: https://archive.apache.org/dist/arrow/arrow-{{ version }}/{{ filename }}
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 2
   # s390x is missing gflags, glog, utf8proc, thrift-cpp
   skip: true  # [s390x]
   run_exports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,7 +57,10 @@ requirements:
     - glog 0.5.0
     - grpc-cpp 1.48.2
     - lz4-c 1.9.4
-    - openssl {{ openssl }}
+#    - openssl {{ openssl }}
+    - openssl 1.1.1 # [openssl_variant == "current"]
+    - openssl 3.0 # [openssl_variant == "legacy"]
+
     - orc 1.7.4
     - libprotobuf {{ libprotobuf }}
     - rapidjson 1.1.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,15 +8,14 @@
 
 package:
   name: arrow-cpp
-  version: {{ version }}
+  version: {{ version }}+openssl1
 
 source:
-  fn: {{ filename }}
   url: https://archive.apache.org/dist/arrow/arrow-{{ version }}/{{ filename }}
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 0
   # s390x is missing gflags, glog, utf8proc, thrift-cpp
   skip: true  # [s390x]
   run_exports:
@@ -47,8 +46,8 @@ requirements:
     # abseil-cpp 20230802.0 causing the UnsatisfibleDependency error so for this rebuild to work, 
     # we need to pin it to the version 20211102.0 like it was done for arrow-cpp 11.0.0.
     - abseil-cpp 20211102.0  # [not osx]
-    - aws-sdk-cpp 1.8.185
-    - boost-cpp 1.82
+    - aws-sdk-cpp 1.8.185 
+    - boost-cpp {{ boost }}
     - brotli 1.0.9
     - bzip2 1.0.8
     # Only required and used on Windows.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,8 +9,8 @@
 
 # IMPORTANT NOTICE!!!
 # This package relies on openssl 1.x so its dependency tree is the next:
-# snowpark_python 1.7.0+openssl1 (submodule and folder are snowpark-python-1.7.0-feedstock; the branch is ...)
-#  └─ snowflake_connector 3.2.0+openssl1 (submodule and folder are snowflake-connector-python-3.2.0-feedstock; the branch is ...)
+# snowpark_python 1.7.0+openssl1 (submodule and folder are snowpark-python-1.7.0-feedstock; the branch is main-1.8.0)
+#  └─ snowflake_connector 3.2.0+openssl1 (submodule and folder are snowflake-connector-python-3.2.0-feedstock; the branch is master-3.2.0)
 # ===>     └─ arrow_cpp 10.0.1+openssl1 (submodule and folder are arrow-cpp-10.0.1-openssl1-feedstock; the branch is arrow-cpp-10.0.1)
 #          └─ openssl 1.x
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,6 +6,13 @@
 {% set filename = "apache-arrow-" + version + ".tar.gz" %}
 {% set sha256 = "c814e0670112a22c1a6ec03ab420a52ae236a9a42e9e438c3cbd37f37e658fb3" %}
 
+
+# IMPORTANT NOTICE!!!
+# This package relies on openssl 1.x so its dependency tree is the next:
+# snowpark_python 1.7.0+openssl1 (submodule and folder are snowpark-python-1.7.0-feedstock; the branch is ...)
+#  └─ snowflake_connector 3.2.0+openssl1 (submodule and folder are snowflake-connector-python-3.2.0-feedstock; the branch is ...)
+# ===>     └─ arrow_cpp 10.0.1+openssl1 (submodule and folder are arrow-cpp-10.0.1-openssl1-feedstock; the branch is arrow-cpp-10.0.1)
+#          └─ openssl 1.x
 package:
   name: arrow-cpp
   version: {{ version }}+openssl1


### PR DESCRIPTION
- introduce new 10.0.1+openssl1 version to be used by snowflake
- remove python from cmake ( pure C/C++ build)
- add openssl 1.1 to local conda_build_config.yaml
- reset build number
- use boost from global conda_build_config.yaml
