### PR TITLE
Arrow-cpp 17.0.0 Rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   sha256: 9d280d8042e7cf526f8c28d170d93bfab65e50f94569f6a790982a878d8d898d
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage("arrow-cpp", max_pin="x.x.x") }}
   missing_dso_whitelist:
@@ -36,7 +36,7 @@ requirements:
     - ninja
   host:
     - libabseil 20240116.2
-    - aws-sdk-cpp 1.10.55
+    - aws-sdk-cpp 1.11.212
     - aws-crt-cpp 0.18.16
     - boost-cpp {{ boost }}
     - brotli 1.0.9


### PR DESCRIPTION
> ## ☆Arrow-cpp 17.0.0 Rebuild☆
> [Jira Ticket](https://anaconda.atlassian.net/browse/PKG-6331) 
[Upstream](https://github.com/apache/arrow)
> 
> ### Changes
> * Updated build number
> * Updated pinning in `host` section for `aws-sdk-cpp` to  `1.11.212`
