### PR TITLE
Fix a path issue on linux-64

### DIFF
--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# for the gdb-wrappers, we need to create a symlink that
+# contains the full path of the lib _within_ the installed
+# env, which we don't have until the env is created.
+
+# doesn't come with a deactivate script, because the symlink
+# is benign and doesn't need to be deleted.
+
+_la_log() {
+    if [ "${CF_LIBARROW_ACTIVATE_LOGGING:-}" = "1" ]; then
+        # The following loop is necessary to handle multi-line strings
+        # like for the output of `ls -al`.
+        printf '%s\n' "$*" | while IFS= read -r line
+        do
+            echo "$CONDA_PREFIX/etc/conda/activate.d/libarrow_activate.sh DEBUG: $line"
+        done
+    fi
+}
+
+# Skip activation if CONDA_BUILD environment variable is set.
+# (CONDA_BUILD is also set in the test stage, and we don't want to skip there.)
+# Otherwise, the symlinks will be included in packages built with libarrow as a host dependency.
+# see https://github.com/conda-forge/arrow-cpp-feedstock/issues/1478
+if [ -n "${CONDA_BUILD:-}" ] && [ "${CONDA_BUILD_STATE:-0}" != "TEST" ]; then
+    _la_log "CONDA_BUILD is set to $CONDA_BUILD (and CONDA_BUILD_STATE != \"TEST\"), skipping libarrow activation."
+    return 0
+fi
+
+_la_log "Beginning libarrow activation."
+
+# where the GDB wrappers get installed
+_la_gdb_prefix="$CONDA_PREFIX/share/gdb/auto-load"
+
+# If the directory is not writable, nothing can be done
+if [ ! -w "$_la_gdb_prefix" ]; then
+    _la_log 'No rights to modify $_la_gdb_prefix, cannot create symlink!'
+    _la_log 'Unless you plan to use the GDB debugger with libarrow, this warning can be safely ignored.'
+    return
+fi
+
+# this needs to be in sync with ARROW_GDB_INSTALL_DIR in build.sh
+_la_placeholder="replace_this_section_with_absolute_slashed_path_to_CONDA_PREFIX"
+# the paths here are intentionally stacked, see #935, resp.
+# https://github.com/apache/arrow/blob/master/docs/source/cpp/gdb.rst#manual-loading
+_la_symlink_dir="$_la_gdb_prefix/$CONDA_PREFIX/lib"
+_la_orig_install_dir="$_la_gdb_prefix/$_la_placeholder/lib"
+
+_la_log "          _la_gdb_prefix: $_la_gdb_prefix"
+_la_log "         _la_placeholder: $_la_placeholder"
+_la_log "         _la_symlink_dir: $_la_symlink_dir"
+_la_log "    _la_orig_install_dir: $_la_orig_install_dir"
+_la_log "  content of that folder:"
+_la_log "$(ls -al "$_la_orig_install_dir" | sed 's/^/      /')"
+
+# there's only one lib in the _la_orig_install_dir folder, but the libname changes
+# based on the version so use a loop instead of hardcoding it.
+for _la_target in "$_la_orig_install_dir/"*.py; do
+    if [ ! -e "$_la_target" ]; then
+        # If the file doesn't exist, skip this iteration of the loop.
+        # (This happens when no files are found, in which case the
+        # loop runs with target equal to the pattern itself.)
+        _la_log 'Folder $_la_orig_install_dir seems to not contain .py files, skipping.'
+        continue
+    fi
+    _la_symlink="$_la_symlink_dir/$(basename "$_la_target")"
+    _la_log "   _la_target: $_la_target"
+    _la_log "  _la_symlink: $_la_symlink"
+    if [ -L "$_la_symlink" ] && [ "$(readlink "$_la_symlink")" = "$_la_target" ]; then
+        _la_log 'symlink $_la_symlink already exists and points to $_la_target, skipping.'
+        continue
+    fi
+    _la_log 'Creating symlink $_la_symlink pointing to $_la_target.'
+    mkdir -p "$_la_symlink_dir" || true
+    # this check also creates the symlink; if it fails, we enter the if-branch.
+    if ! ln -sf "$_la_target" "$_la_symlink"; then
+        echo -n "${BASH_SOURCE[0]} WARNING: Failed to create symlink from "
+        echo "'$_la_target' to '$_la_symlink'!"
+        echo "Unless you plan to use the GDB debugger with libarrow, this warning can be safely ignored."
+        continue
+    fi
+done
+
+_la_log "Libarrow activation complete."
+
+unset _la_gdb_prefix
+unset _la_log
+unset _la_orig_install_dir
+unset _la_placeholder
+unset _la_symlink
+unset _la_symlink_dir
+unset _la_target

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,6 +6,7 @@ set -x
 mkdir cpp/build
 pushd cpp/build
 
+# placeholder in ARROW_GDB_INSTALL_DIR must match _la_placeholder in activate.sh
 cmake -GNinja \
     ${CMAKE_ARGS} \
     -DCMAKE_BUILD_TYPE=Release \
@@ -28,6 +29,7 @@ cmake -GNinja \
     -DARROW_FLIGHT_SQL=ON \
     -DARROW_GANDIVA=OFF \
     -DARROW_GCS=OFF \
+    -DARROW_GDB_INSTALL_DIR=replace_this_section_with_absolute_slashed_path_to_CONDA_PREFIX/lib \
     -DARROW_HDFS=ON \
     -DARROW_JEMALLOC=ON \
     -DARROW_JSON=ON \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   sha256: f89b93f39954740f7184735ff1e1d3b5be2640396febc872c4955274a011f56b
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage("arrow-cpp", max_pin="x.x.x") }}
   missing_dso_whitelist:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7250](https://anaconda.atlassian.net/browse/PKG-7250) 
- [source code](https://github.com/apache/arrow/tree/apache-arrow-19.0.0)
- [conda-forge](https://github.com/conda-forge/arrow-cpp-feedstock)

### Explanation of changes:

- Bump the build number to `1.`
- Add `DARROW_GDB_INSTALL_DIR` to `build.sh`
- Add `activate.sh`

### Issue:

There is a report on the forum of a file name too long issue for `arrow-cpp `for a user running Linux Mint.  

`InvalidArchiveError(“Error with archive /home/gonzalo/miniconda3/pkgs/arrow-cpp-19.0.0-h865e1df_0.conda. You probably need to delete and re-download or re-create this file. Message was:\n\nfailed with error: [Errno 36] File name too long: ‘/home/gonzalo/miniconda3/pkgs/arrow-cpp-19.0.0-h865e1df_0/share/gdb/auto-load/croot/arrow-cpp_1738050279978/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeho’”)`

[Trouble installing anaconda from miniconda](https://community.anaconda.cloud/t/trouble-installing-anaconda-from-miniconda/92821)

### Solving:

1. If we download https://anaconda.org/anaconda/arrow-cpp/19.0.0/download/linux-64/arrow-cpp-19.0.0-h865e1df_0.tar.bz2 from https://anaconda.org/anaconda/arrow-cpp/files, extract, and then grepping `"share/gdb/auto-load"`:

```
cd arrow-cpp-19.0.0-h865e1df_0

➜  arrow-cpp-19.0.0-h865e1df_0 rg "share/gdb/auto-load"
info/has_prefix
32:/croot/arrow-cpp_1738050279978/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeho text share/gdb/auto-load/croot/arrow-cpp_1738050279978/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeho/lib/libarrow.so.1900.0.0-gdb.py

info/files
526:share/gdb/auto-load/croot/arrow-cpp_1738050279978/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeho/lib/__pycache__/libarrow.so.1900.0.0-gdb.cpython-313.pyc
527:share/gdb/auto-load/croot/arrow-cpp_1738050279978/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeho/lib/libarrow.so.1900.0.0-gdb.py

info/paths.json
3216:      "_path": "share/gdb/auto-load/croot/arrow-cpp_1738050279978/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeho/lib/__pycache__/libarrow.so.1900.0.0-gdb.cpython-313.pyc",
3222:      "_path": "share/gdb/auto-load/croot/arrow-cpp_1738050279978/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeho/lib/libarrow.so.1900.0.0-gdb.py",
```

2. After modifying the recipe (`build.sh`) and adding `activate.sh` (from the conda-forge recipe), we can download artifacts from the staging channel (for `linux-64` https://staging.continuum.io/prefect/fs/arrow-cpp-feedstock/pr47/3b7e1d5/linux-64) -> https://staging.continuum.io/prefect/fs/arrow-cpp-feedstock/pr47/3b7e1d5/linux-64/arrow-cpp-19.0.0-h865e1df_1.tar.bz2, extract, and then grepping `"share/gdb/auto-load"` will output much shorter folder paths

```
cd arrow-cpp-19.0.0-h865e1df_1
➜  arrow-cpp-19.0.0-h865e1df_1 rg "share/gdb/auto-load"
info/has_prefix
31:/croot/arrow-cpp_1742470817748/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeho text share/gdb/auto-load/replace_this_section_with_absolute_slashed_path_to_CONDA_PREFIX/lib/libarrow.so.1900.0.0-gdb.py

info/files
526:share/gdb/auto-load/replace_this_section_with_absolute_slashed_path_to_CONDA_PREFIX/lib/__pycache__/libarrow.so.1900.0.0-gdb.cpython-313.pyc
527:share/gdb/auto-load/replace_this_section_with_absolute_slashed_path_to_CONDA_PREFIX/lib/libarrow.so.1900.0.0-gdb.py

info/paths.json
3214:      "_path": "share/gdb/auto-load/replace_this_section_with_absolute_slashed_path_to_CONDA_PREFIX/lib/__pycache__/libarrow.so.1900.0.0-gdb.cpython-313.pyc",
3220:      "_path": "share/gdb/auto-load/replace_this_section_with_absolute_slashed_path_to_CONDA_PREFIX/lib/libarrow.so.1900.0.0-gdb.py",

info/recipe/activate.sh
33:_la_gdb_prefix="$CONDA_PREFIX/share/gdb/auto-load"
```

[PKG-7250]: https://anaconda.atlassian.net/browse/PKG-7250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ