### PR TITLE
Fix __cuda virtual package for host dep compatibility

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@
 {% set name = "arrow-cpp" %}
 {% set version = "23.0.1" %}
 {% set filename = "apache-arrow-" + version + ".tar.gz" %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 {% set cuda_enabled = (gpu_variant or "").startswith("cuda") %}
 
 package:
@@ -103,7 +103,12 @@ requirements:
     - c-ares  # [win]
     # CUDA runtime dependencies
     - {{ pin_compatible('cuda-version', max_pin='x.x') }}  # [(gpu_variant or "").startswith("cuda")]
-    - __cuda                                                # [(gpu_variant or "").startswith("cuda")]
+  run_constrained:
+    # __cuda in run would block downstream packages (e.g. pyarrow) from installing
+    # arrow-cpp CUDA as a host dep in build environments without a GPU.
+    # Use run_constrained so the solver doesn't require __cuda at build time.
+    # Downstream packages (pyarrow) add __cuda to their own run deps.
+    - __cuda  # [(gpu_variant or "").startswith("cuda")]
 
 test:
   requires:


### PR DESCRIPTION
arrow-cpp 23.0.1

**Destination channel:** defaults

### Links

- [PKG-13005](https://anaconda.atlassian.net/browse/PKG-13005)
- [Upstream repository](https://github.com/apache/arrow)
- Relevant dependency PRs:
  - [arrow-cpp CUDA PR#59](https://github.com/AnacondaRecipes/arrow-cpp-feedstock/pull/59) — merged
  - [pyarrow CUDA PR#29](https://github.com/AnacondaRecipes/pyarrow-feedstock/pull/29) — blocked on this fix

### Explanation of changes:

- Move `__cuda` from `run` to `run_constrained` for CUDA variants
- Bump build number to 1
- **Why**: When pyarrow installs `arrow-cpp cuda128*` as a host dep, the solver tries to satisfy all of arrow-cpp's run deps including `__cuda`. PBP graph generation environment has no GPU, so `__cuda` virtual package is unavailable → solver fails. Moving to `run_constrained` allows arrow-cpp CUDA to be installed in host environments without a GPU. pyarrow adds `__cuda` to its own run deps to ensure CUDA driver at user install time.

[PKG-13005]: https://anaconda.atlassian.net/browse/PKG-13005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ