### PR TITLE
arrow-cpp rebuild against libabseil 20250814.1

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -18,9 +18,18 @@ zip_keys:
 
 libabseil:
   - '20250814.1'
+  - '20260107'
 
 libgrpc:
   - '1.74.1'
+  - '1.78'
 
 libprotobuf:
-  - '6.33.0'
+  - 6.33.0
+  - 6.33.5
+
+zip_keys:
+  -
+    - libabseil
+    - libgrpc
+    - libprotobuf

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -15,3 +15,12 @@ zip_keys:
   -
     - gpu_variant
     - cuda_compiler_version
+
+libabseil:
+  - '20250814.1'
+
+libgrpc:
+  - '1.74.1'
+
+libprotobuf:
+  - '6.33.0'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@
 {% set name = "arrow-cpp" %}
 {% set version = "23.0.1" %}
 {% set filename = "apache-arrow-" + version + ".tar.gz" %}
-{% set build_number = 1 %}
+{% set build_number = 2 %}
 {% set cuda_enabled = (gpu_variant or "").startswith("cuda") %}
 
 package:


### PR DESCRIPTION
arrow-cpp rebuild against libabseil 20250814.1

### Links

* [PKG-13073](https://anaconda.atlassian.net/browse/PKG-13073)
* Upstream repo: https://github.com/apache/arrow
* Conda-Forge repo: https://github.com/AnacondaRecipes/arrow-cpp-feedstock

### Explanation of changes:

* Building against an additional version of libabseil to solve complex dependencies with vLLM and opencv.
* Bumping build number

[PKG-13073]: https://anaconda.atlassian.net/browse/PKG-13073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ