### PR TITLE
arrow-cpp 23.0.1 CUDA 12.9 rebuild (PKG-13202)

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -4,7 +4,7 @@ gpu_variant:
   - cuda-13                         # [linux]
 cuda_compiler_version:
   - none
-  - 12.8                            # [linux]
+  - 12.9                            # [linux]
   - 13.1                            # [linux]
 
 # cuda_compiler (cuda-nvcc) inherited from aggregate CBC — not redefined here.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@
 {% set name = "arrow-cpp" %}
 {% set version = "23.0.1" %}
 {% set filename = "apache-arrow-" + version + ".tar.gz" %}
-{% set build_number = 1 %}
+{% set build_number = 2 %}
 {% set cuda_enabled = (gpu_variant or "").startswith("cuda") %}
 
 package:


### PR DESCRIPTION
arrow-cpp 23.0.1

**Destination channel:** defaults

### Links

- [PKG-13202](https://anaconda.atlassian.net/browse/PKG-13202)
- [Upstream repository](https://github.com/apache/arrow)

### Explanation of changes:

- Bump `cuda_compiler_version` for the `cuda-12` variant from `12.8` to `12.9`


[PKG-13202]: https://anaconda.atlassian.net/browse/PKG-13202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ