### PR TITLE
deploy activation script, set cuda to default version, use libutf8proc

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -71,3 +71,9 @@ cmake -GNinja \
 ninja -v install
 
 popd
+
+# Copy the activate script to $PREFIX/etc/conda/activate.d
+for CHANGE in "activate"; do
+    mkdir -p "${PREFIX}/etc/conda/${CHANGE}.d"
+    cp "${RECIPE_DIR}/${CHANGE}.sh" "${PREFIX}/etc/conda/${CHANGE}.d/${PKG_NAME}_${CHANGE}.sh"
+done

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -5,7 +5,7 @@ gpu_variant:
 cuda_compiler_version:
   - none
   - 12.9                            # [win or linux]
-  - 13.1                            # [win or linux]
+  - 13.0                            # [win or linux]
 
 # cuda_compiler (cuda-nvcc) inherited from aggregate CBC — not redefined here.
 # No GCC downgrade needed: Arrow does not compile .cu files (no nvcc invocation).

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,8 +50,8 @@ requirements:
     - ninja-base
   host:
     - libabseil {{ libabseil }}
-    - aws-sdk-cpp 1.11.774
-    - aws-crt-cpp 0.37.4
+    - aws-sdk-cpp {{ aws_sdk_cpp }}
+    - aws-crt-cpp {{ aws_crt_cpp }}
     - libboost-devel {{ libboost_devel }}
     - brotli {{ brotli }}
     - bzip2 {{ bzip2 }}
@@ -111,8 +111,6 @@ requirements:
     - __cuda  # [(gpu_variant or "").startswith("cuda")]
 
 test:
-  requires:
-    - conda-build
   commands:
     # headers
     - test -f $PREFIX/include/arrow/api.h              # [unix]
@@ -154,10 +152,6 @@ test:
     - test -f $PREFIX/share/gdb/auto-load/$PREFIX/lib/libarrow.so.{{ so_version }}-gdb.py     # [linux]
     - test -f $PREFIX/share/gdb/auto-load/$PREFIX/lib/libarrow.{{ so_version }}.dylib-gdb.py  # [osx]
 
-    # conda tools
-    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
-    - conda inspect objects -p $PREFIX $PKG_NAME   # [osx]
-
 about:
   home: https://github.com/apache/arrow
   license: Apache-2.0
@@ -172,10 +166,6 @@ about:
   doc_url: https://arrow.apache.org
 
 extra:
-  skip-lints:
-    # There are no Python tests for this project. All tests are executed as
-    # shell scripts.
-    - missing_imports_or_run_test_py
   recipe-maintainers:
     - wesm
     - xhochy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,6 +7,8 @@
 {% set filename = "apache-arrow-" + version + ".tar.gz" %}
 {% set build_number = 5 %}
 {% set cuda_enabled = (gpu_variant or "").startswith("cuda") %}
+{# see https://github.com/apache/arrow/blob/apache-arrow-{{ version }}/cpp/CMakeLists.txt#L131-L145 #}
+{% set so_version = (version.split(".")[0] | int * 100 + version.split(".")[1] | int) ~ "." ~ version.split(".")[2] ~ ".0" %}
 
 package:
   name: {{ name|lower }}
@@ -152,6 +154,10 @@ test:
     - if not exist %PREFIX%\\Library\\bin\\arrow_cuda.dll exit 1                   # [win and (gpu_variant or "").startswith("cuda")]
     - if not exist %PREFIX%\\Library\\lib\\arrow_cuda.lib exit 1                   # [win and (gpu_variant or "").startswith("cuda")]
     - if not exist %PREFIX%\\Library\\include\\arrow\\gpu\\cuda_api.h exit 1       # [win and (gpu_variant or "").startswith("cuda")]
+
+    # gdb-wrapper (paths are stacked intentionally)
+    - test -f $PREFIX/share/gdb/auto-load/$PREFIX/lib/libarrow.so.{{ so_version }}-gdb.py     # [linux]
+    - test -f $PREFIX/share/gdb/auto-load/$PREFIX/lib/libarrow.{{ so_version }}.dylib-gdb.py  # [osx]
 
     # conda tools
     - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@
 {% set name = "arrow-cpp" %}
 {% set version = "23.0.1" %}
 {% set filename = "apache-arrow-" + version + ".tar.gz" %}
-{% set build_number = 4 %}
+{% set build_number = 5 %}
 {% set cuda_enabled = (gpu_variant or "").startswith("cuda") %}
 
 package:
@@ -70,7 +70,7 @@ requirements:
     - libre2-11 {{ libre2_11 }}
     - snappy {{ snappy }}
     - thrift-cpp {{ libthrift }}
-    - utf8proc {{ libutf8proc }}
+    - libutf8proc {{ libutf8proc }}
     - zlib {{ zlib }}
     - zstd {{ zstd }}
     - xsimd 13.0.0
@@ -84,7 +84,6 @@ requirements:
     # ships inside cuda-cudart-dev_win-64 (matches conda-forge libarrow pattern).
     - cuda-driver-dev {{ cuda_compiler_version }}  # [linux and (gpu_variant or "").startswith("cuda")]
   run:
-    - {{ pin_compatible('utf8proc', max_pin='x') }}
     # Through run_exports
     - aws-crt-cpp
     - aws-sdk-cpp
@@ -96,6 +95,7 @@ requirements:
     - libgrpc
     - libprotobuf
     - libthrift
+    - libutf8proc
     - lz4-c
     - openssl
     - orc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,10 +4,9 @@
 # hashes should match.
 {% set name = "arrow-cpp" %}
 {% set version = "23.0.1" %}
-{% set filename = "apache-arrow-" + version + ".tar.gz" %}
 {% set build_number = 5 %}
 {% set cuda_enabled = (gpu_variant or "").startswith("cuda") %}
-{# see https://github.com/apache/arrow/blob/apache-arrow-{{ version }}/cpp/CMakeLists.txt#L131-L145 #}
+# see https://github.com/apache/arrow/blob/apache-arrow-23.0.1/cpp/CMakeLists.txt#L131-L145
 {% set so_version = (version.split(".")[0] | int * 100 + version.split(".")[1] | int) ~ "." ~ version.split(".")[2] ~ ".0" %}
 
 package:
@@ -15,16 +14,12 @@ package:
   version: {{ version }}
 
 source:
-  url: https://archive.apache.org/dist/arrow/arrow-{{ version }}/{{ filename }}
+  url: https://archive.apache.org/dist/arrow/arrow-{{ version }}/apache-arrow-{{ version }}.tar.gz
   sha256: bd09adb4feac11fe49d1604f296618866702be610c86e2d513b561d877de6b18
 
 build:
   number: {{ build_number + 100 if cuda_enabled else build_number }}
-  {% if cuda_enabled %}
-  string: cuda{{ cuda_compiler_version | replace('.', '') }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
-  {% else %}
-  string: cpu_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
-  {% endif %}
+  string: {{ "cuda"~cuda_compiler_version | replace('.', '') if cuda_enabled else "cpu" }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
   run_exports:
     - {{ pin_subpackage("arrow-cpp", max_pin="x.x.x") }}
   missing_dso_whitelist:
@@ -57,7 +52,7 @@ requirements:
     - libabseil {{ libabseil }}
     - aws-sdk-cpp 1.11.774
     - aws-crt-cpp 0.37.4
-    - boost-cpp
+    - libboost-devel {{ libboost_devel }}
     - brotli {{ brotli }}
     - bzip2 {{ bzip2 }}
     # Only required and used on Windows.


### PR DESCRIPTION
- Use libutf8proc instead of utf8proc
- Default to cuda 12.9 and 13.0 to align with global cbc.
- Deploy activation script to properly handle gdp script at runtime (https://anaconda.slack.com/archives/C05BAMC4S04/p1781089273769849)